### PR TITLE
fix compile error for posix-mros2

### DIFF
--- a/src/mros2.cpp
+++ b/src/mros2.cpp
@@ -26,10 +26,10 @@
 
 #include "TEST.hpp"
 
-#ifndef __MBED__
+#ifdef USE_ASP3_FOR_STM
 /* Statement to avoid link error */
 void* __dso_handle=0;
-#endif /* __MBED__ */
+#endif /* USE_ASP3_FOR_STM */
 
 
 namespace mros2
@@ -238,7 +238,7 @@ template <class T>
 void Subscriber::callback_handler(void *callee, const rtps::ReaderCacheChange &cacheChange)
 {
   T msg;
-  msg.copyFromBuf(&cacheChange.data[4]);
+  msg.copyFromBuf(&cacheChange.getData()[4]);
 
   SubscribeDataType *sub = (SubscribeDataType *)callee;
   void (*fp)(intptr_t) = sub->cb_fp;


### PR DESCRIPTION
# Background
mros2 is for embedded machines, but I'm trying to run mros2 on Linux process  using [embeddedRTPS-Linux](https://github.com/embedded-software-laboratory/embeddedRTPS-Linux).

# Problem(compile error for posix mros2)
1.  __dso_handle is not needed 
2.  callback_handler is accessing private member  `data` of ReaderCacheChange class

# Fix
1. __dso_handle is compiled only defined USE_ASP3_FOR_STM macro
2.  use getData() instead of accesing private member `data`