### PR TITLE
remove embeddedRTPS/src/rtps.cpp from make target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,6 @@ target_sources(mros2
   embeddedRTPS/src/communication/UdpDriver.cpp
   embeddedRTPS/src/messages/MessageTypes.cpp
   embeddedRTPS/src/messages/MessageReceiver.cpp
-  embeddedRTPS/src/rtps.cpp
   embeddedRTPS/src/discovery/TopicData.cpp
   embeddedRTPS/src/discovery/ParticipantProxyData.cpp
   embeddedRTPS/src/discovery/SEDPAgent.cpp

--- a/makefiles/Makefile.rtps
+++ b/makefiles/Makefile.rtps
@@ -36,7 +36,6 @@ APPL_CXXOBJS += MessageTypes.o
 APPL_CXXOBJS += HistoryCache.o
 APPL_CXXOBJS += PBufWrapper.o
 APPL_CXXOBJS += SimpleHistoryCache.o
-APPL_CXXOBJS += rtps.o
 APPL_CXXOBJS += ThreadPool.o
 
 APPL_COBJS += array.o


### PR DESCRIPTION
We observed `embeddedRTPS/src/rtps.cpp` is not needed for mros2 build. So we decide to remove it from make/cmake target.