### PR TITLE
move `__dso_handle` to mros2-asp3-f767zi

### DIFF
--- a/makefiles/Makefile.lwip
+++ b/makefiles/Makefile.lwip
@@ -81,3 +81,4 @@ APPL_COBJS  += stm32f7xx_hal_pcd.o
 APPL_COBJS  += stm32f7xx_hal_pcd_ex.o
 APPL_COBJS  += stm32f7xx_ll_usb.o
 APPL_COBJS  += syscalls.o
+APPL_COBJS  += dso_handle.o

--- a/src/mros2.cpp
+++ b/src/mros2.cpp
@@ -26,11 +26,6 @@
 
 #include "TEST.hpp"
 
-#ifdef USE_ASP3_FOR_STM
-/* Statement to avoid link error */
-void* __dso_handle=0;
-#endif /* USE_ASP3_FOR_STM */
-
 
 namespace mros2
 {


### PR DESCRIPTION
Since the definition of `__dso_handle` is specific to the target about `mros2-asp3-f767zi` (mros2 with TOPPERS/ASP3 kernel and STM32CubeMX lib), we decided to move this definition to `mros2-asp3-f767zi` repository.