### PR TITLE
fix for posix cmake build support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,16 @@
 # Copyright (c) 2021 smorita_emb
 # SPDX-License-Identifier: Apache-2.0
 
+cmake_minimum_required(VERSION 3.16.3)
+
+project(mros2
+    LANGUAGES C CXX
+)
+
+if (DEFINED CMAKE_OS_POSIX)
+    include(cmake-build/posix.cmake)
+else()
+
 target_include_directories(mros2
   BEFORE INTERFACE
   embeddedRTPS/thirdparty/Micro-CDR/include
@@ -32,3 +42,4 @@ target_sources(mros2
   embeddedRTPS/thirdparty/Micro-CDR/src/c/types/sequence.c
   embeddedRTPS/thirdparty/Micro-CDR/src/c/types/array.c
 )
+endif()

--- a/cmake-build/Filelists.cmake
+++ b/cmake-build/Filelists.cmake
@@ -1,0 +1,23 @@
+set(mros2_SRCS
+  ${MROS2_DIR}/src/mros2.cpp
+  ${MROS2_DIR}/embeddedRTPS/src/communication/UdpDriver.cpp
+  ${MROS2_DIR}/embeddedRTPS/src/messages/MessageTypes.cpp
+  ${MROS2_DIR}/embeddedRTPS/src/messages/MessageReceiver.cpp
+  ${MROS2_DIR}/embeddedRTPS/src/discovery/TopicData.cpp
+  ${MROS2_DIR}/embeddedRTPS/src/discovery/ParticipantProxyData.cpp
+  ${MROS2_DIR}/embeddedRTPS/src/discovery/SEDPAgent.cpp
+  ${MROS2_DIR}/embeddedRTPS/src/discovery/SPDPAgent.cpp
+  ${MROS2_DIR}/embeddedRTPS/src/storages/HistoryCache.cpp
+  ${MROS2_DIR}/embeddedRTPS/src/storages/SimpleHistoryCache.cpp
+  ${MROS2_DIR}/embeddedRTPS/src/storages/PBufWrapper.cpp
+  ${MROS2_DIR}/embeddedRTPS/src/ThreadPool.cpp
+  ${MROS2_DIR}/embeddedRTPS/src/entities/Participant.cpp
+  ${MROS2_DIR}/embeddedRTPS/src/entities/Domain.cpp
+  ${MROS2_DIR}/embeddedRTPS/src/entities/StatelessReader.cpp
+  ${MROS2_DIR}/embeddedRTPS/thirdparty/Micro-CDR/src/c/common.c
+  ${MROS2_DIR}/embeddedRTPS/thirdparty/Micro-CDR/src/c/types/basic.c
+  ${MROS2_DIR}/embeddedRTPS/thirdparty/Micro-CDR/src/c/types/string.c
+  ${MROS2_DIR}/embeddedRTPS/thirdparty/Micro-CDR/src/c/types/sequence.c
+  ${MROS2_DIR}/embeddedRTPS/thirdparty/Micro-CDR/src/c/types/array.c
+)
+

--- a/cmake-build/default-cmake-options.cmake
+++ b/cmake-build/default-cmake-options.cmake
@@ -1,0 +1,23 @@
+
+set(CMAKE_C_FLAGS "-std=gnu99")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O0")
+set(CMAKE_C_FLAGS  "${CMAKE_C_FLAGS} -Wall")
+set(CMAKE_C_FLAGS  "${CMAKE_C_FLAGS} -Wunknown-pragmas")
+set(CMAKE_C_FLAGS  "${CMAKE_C_FLAGS} -Wtrigraphs")
+set(CMAKE_C_FLAGS  "${CMAKE_C_FLAGS} -Wimplicit-int")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O0")
+
+add_compile_definitions(OS_POSIX)
+add_compile_definitions(osObjectsExternal)
+add_compile_definitions(STM32F767xx)
+
+set(cmsis_DIR "${PROJECT_SOURCE_DIR}/../cmsis-posix/public")
+message(STATUS "cmsis_DIR=${cmsis_DIR}")
+find_package(cmsis REQUIRED)
+
+set(lwip_DIR "${PROJECT_SOURCE_DIR}/../lwip-posix/public")
+message(STATUS "lwip_DIR=${lwip_DIR}")
+find_package(lwip REQUIRED)
+

--- a/cmake-build/posix.cmake
+++ b/cmake-build/posix.cmake
@@ -1,0 +1,84 @@
+
+if (DEFINED MROS2_POSIX_OPTION_FILEPATH)
+	include(${MROS2_POSIX_OPTION_FILEPATH})
+else()
+	message(STATUS "MROS2_POSIX_OPTION_FILEPATH is not defined")
+	include(cmake-build/default-cmake-options.cmake)
+endif()
+
+# ASSERTION CHECK 
+if (NOT DEFINED cmsis_DIR)
+	message(FATAL " cmsis_DIR is not defined")
+endif()
+if (NOT DEFINED lwip_DIR)
+	message(FATAL " lwip_DIR is not defined")
+endif()
+message(STATUS "CMAKE_OS_POSIX=" ${CMAKE_OS_POSIX})
+
+set(MROS2_DIR "${PROJECT_SOURCE_DIR}")
+include(cmake-build/Filelists.cmake)
+
+
+add_library(
+	mros2 STATIC
+	${mros2_SRCS}
+)
+
+target_include_directories(
+	mros2
+
+	#embeddedRTPS
+	PRIVATE ${MROS2_DIR}/embeddedRTPS/include
+	PRIVATE ${MROS2_DIR}/embeddedRTPS/thirdparty/Micro-CDR/include
+	PRIVATE ${RTPS_CONFIG_INCLUDE_DIR}
+
+	#mROS2
+	PRIVATE ${MROS2_DIR}/include
+	PRIVATE ${MROS2_DIR}/mros2_msgs
+
+	#CMSIS INCLUDES
+	PRIVATE ${cmsis_DIR}/include
+
+	#LWIP INCLUDES
+	PRIVATE ${lwip_DIR}/include/lwip
+	PRIVATE ${lwip_DIR}/include/posix
+	PRIVATE ${lwip_DIR}/include/system
+	PRIVATE ${lwip_DIR}/include/netif
+)
+
+set(INSTALL_CMAKE_DIR ${PROJECT_SOURCE_DIR}/public)
+message(STATUS "INSTALL_CMAKE_DIR=" ${INSTALL_CMAKE_DIR})
+
+install(
+	DIRECTORY ${MROS2_DIR}/include/
+	DESTINATION ${INSTALL_CMAKE_DIR}/include/mros2
+)
+
+install(
+	DIRECTORY ${MROS2_DIR}/mros2_msgs/
+	DESTINATION ${INSTALL_CMAKE_DIR}/include/mros2_msgs
+)
+
+install(
+	DIRECTORY ${MROS2_DIR}/embeddedRTPS/include/rtps/
+	DESTINATION ${INSTALL_CMAKE_DIR}/include/rtps
+)
+install(
+	DIRECTORY ${MROS2_DIR}/embeddedRTPS/thirdparty/Micro-CDR/include/ucdr/
+	DESTINATION ${INSTALL_CMAKE_DIR}/include/ucdr
+)
+
+install(
+	TARGETS mros2 
+	DESTINATION     ${INSTALL_CMAKE_DIR} 
+	EXPORT			mros2-export
+	LIBRARY         DESTINATION lib
+	INCLUDES        DESTINATION include
+	PUBLIC_HEADER   DESTINATION include
+)
+install(
+	EXPORT			mros2-export 
+    FILE			mros2-config.cmake
+	DESTINATION		${INSTALL_CMAKE_DIR}
+    EXPORT_LINK_INTERFACE_LIBRARIES
+)

--- a/src/mros2.cpp
+++ b/src/mros2.cpp
@@ -225,7 +225,6 @@ Subscriber Node::create_subscription(std::string topic_name, int qos, void(*fp)(
   /* Register callback to ensure that a subscriber is matched to the reader before receiving messages */
   part_ptr->registerOnNewPublisherMatchedCallback(subMatch, &pubMatched);
 
-  MROS2_DEBUG("[MROS2LIB] create_subscription complete. data memory address=0x%x", data_p);
   return sub;
 }
 

--- a/src/mros2.cpp
+++ b/src/mros2.cpp
@@ -225,6 +225,8 @@ Subscriber Node::create_subscription(std::string topic_name, int qos, void(*fp)(
   /* Register callback to ensure that a subscriber is matched to the reader before receiving messages */
   part_ptr->registerOnNewPublisherMatchedCallback(subMatch, &pubMatched);
 
+  MROS2_DEBUG("[MROS2LIB] create_subscription complete");
+
   return sub;
 }
 


### PR DESCRIPTION
# Background
mros2 is for embedded machines, but I'm trying to run mros2 on Linux process using embeddedRTPS-Linux.

# Problem
* cmake
  * now CMakeLists.txt is for mbed, but mros2-posix needs some additional commands.
* warning
  * now address debug print is for 32bit, but mros2-posix is for 64bit.  so compile warning is occured.

# Fix
* cmake
  * `cmake_minimum_required` and `project` commands are added
  * `cmake-build` folder is added
* warning
  * address debug print is deleted.