### PR TITLE
remove generation of header_includer

### DIFF
--- a/mros2_header_generator/header_includer.tpl
+++ b/mros2_header_generator/header_includer.tpl
@@ -1,1 +1,0 @@
-#include "../workspace/{{app}}/templates.hpp"

--- a/mros2_header_generator/templates_generator.py
+++ b/mros2_header_generator/templates_generator.py
@@ -43,12 +43,7 @@ def main():
     datatext = template.render({ "includeFiles":includeFiles, "pubMsgTypes":pubMsgTypes, "subMsgTypes":subMsgTypes  })
     with open(os.path.join(app+"/templates.hpp"), "wb") as f:
         f.write(datatext.encode('utf-8'))
-        
-    env = Environment(loader=FileSystemLoader('../mros2/mros2_header_generator'))
-    template = env.get_template('header_includer.tpl')
-    datatext = template.render({ "app": app  })
-    with open(os.path.join("../header_includer/header_includer.hpp"), "wb") as f:
-        f.write(datatext.encode('utf-8'))
-        
+
+
 if __name__ == "__main__":
     main()

--- a/src/mros2.cpp
+++ b/src/mros2.cpp
@@ -274,8 +274,7 @@ void setTrue(void* args)
   *static_cast<volatile bool*>(args) = true;
 }
 
-
 /*
- *  specialize template functions
+ * specialize template functions described in platform's workspace
  */
-#include "../../header_includer/header_includer.hpp"
+#include "templates.hpp"


### PR DESCRIPTION
Since it was just included in two stages, mros2.cpp will include templates.hpp which will be generated into platform's workspace directly from mros2.cpp