### PR TITLE
implement `mros2::setIPAddressRTPS` to move its operation from config/rtps.h

### DIFF
--- a/include/mros2.h
+++ b/include/mros2.h
@@ -13,6 +13,14 @@
 extern void* __dso_handle;
 #endif
 
+namespace rtps
+{
+namespace Config
+{
+extern std::array<uint8_t, 4> IP_ADDRESS;
+}
+}
+
 namespace mros2
 {
 
@@ -80,6 +88,8 @@ private:
 };
 
 void spin();
+
+void setIPAddrRTPS(std::array<uint8_t, 4> ipaddr);
 
 }  /* namespace mros2 */
 

--- a/src/mros2.cpp
+++ b/src/mros2.cpp
@@ -282,6 +282,13 @@ void spin()
   }
 }
 
+void setIPAddrRTPS(std::array<uint8_t, 4> ipaddr)
+{
+  rtps::Config::IP_ADDRESS = ipaddr;
+
+  MROS2_DEBUG("[MROS2LIB] set IP address for RTPS communication");
+}
+
 }  /* namespace mros2 */
 
 
@@ -310,6 +317,14 @@ void setTrue(void* args)
 {
   *static_cast<volatile bool*>(args) = true;
 }
+
+namespace rtps
+{
+namespace Config
+{
+std::array<uint8_t, 4> IP_ADDRESS;
+}
+} /* namespace rtps */
 
 /*
  * specialize template functions described in platform's workspace


### PR DESCRIPTION
Previously, IP address settings were required in both `./include/config/rtps.h` and in `app.cpp`, but I could solve this situation so that it can work with only one setting, in `./platform/mros2-platform.h`.
After the network configuration is complete, the program obtains the IP address and stores it to the configuration for embeddedRTPS (`rtps::Config::IP_ADDRESS`). This may increase the implementation responsibility for each platform, but I believe it should be more convenient for the user.

We have confirmed that this works only with mros2-mbed / echoback_string. Please check along with the following.
https://github.com/mROS-base/mros2-mbed/pull/42