### PR TITLE
use argparse to specify file(s) to generate template.hpp, and change location to execute script and output file

### DIFF
--- a/mros2_header_generator/templates_generator.py
+++ b/mros2_header_generator/templates_generator.py
@@ -1,11 +1,9 @@
 import os
 import sys
 import re
+import argparse
 from os import path
 from jinja2 import Environment, FileSystemLoader
-
-arg = sys.argv
-app = arg[1]
 
 includeFiles = []
 pubMsgTypes = []
@@ -15,7 +13,21 @@ def toSnakeCase(string):
     return re.sub("(.[A-Z])",lambda x:x.group(1)[0] + "_" +x.group(1)[1],string).lower()
 
 def main():
-    with open(app + "/app.cpp", 'r') as m_f:
+    print('Generate template.hpp from mros2 app code file.')
+
+    parser = argparse.ArgumentParser(description='Generate template.hpp from mros2 app code file.')
+    parser.add_argument('--app', default='echoreply_string',
+                    help='application name (default: \'echoreply_string\')')
+    parser.add_argument('--file', nargs='*', type=str, default=['app.cpp'],
+                    help='filename(s) of mros2 app code (default: \'app.cpp\')')
+
+    args = parser.parse_args()
+    app = args.app
+    file = args.file
+
+    for f in file:
+        print('  Analyzing {}/{} file to generate...'.format(app, f))
+        with open(app + "/" + f, 'r') as m_f:
             arr = m_f.readlines()
             for m_line in arr:
                 if "create_publisher" in m_line:
@@ -43,6 +55,8 @@ def main():
     datatext = template.render({ "includeFiles":includeFiles, "pubMsgTypes":pubMsgTypes, "subMsgTypes":subMsgTypes  })
     with open(os.path.join(app+"/templates.hpp"), "wb") as f:
         f.write(datatext.encode('utf-8'))
+
+    print('Generate {}/template.hpp done.'.format(app))
 
 if __name__ == "__main__":
     main()

--- a/mros2_header_generator/templates_generator.py
+++ b/mros2_header_generator/templates_generator.py
@@ -16,18 +16,18 @@ def main():
     print('Generate template.hpp from mros2 app code file.')
 
     parser = argparse.ArgumentParser(description='Generate template.hpp from mros2 app code file.')
-    parser.add_argument('--app', default='echoreply_string',
-                    help='application name (default: \'echoreply_string\')')
+    parser.add_argument('--outdir', default='.',
+                    help='directry name to output template.hpp (default: \'.\' (current dir))')
     parser.add_argument('--file', nargs='*', type=str, default=['app.cpp'],
                     help='filename(s) of mros2 app code (default: \'app.cpp\')')
 
     args = parser.parse_args()
-    app = args.app
+    outdir = args.outdir
     file = args.file
 
     for f in file:
-        print('  Analyzing {}/{} file to generate...'.format(app, f))
-        with open(app + "/" + f, 'r') as m_f:
+        print('  Analyzing \'{}\' to generate...'.format(f))
+        with open(f, 'r') as m_f:
             arr = m_f.readlines()
             for m_line in arr:
                 if "create_publisher" in m_line:
@@ -53,10 +53,10 @@ def main():
     env = Environment(loader=FileSystemLoader(path.dirname(__file__)))
     template = env.get_template('templates.tpl')
     datatext = template.render({ "includeFiles":includeFiles, "pubMsgTypes":pubMsgTypes, "subMsgTypes":subMsgTypes  })
-    with open(os.path.join(app+"/templates.hpp"), "wb") as f:
+    with open(os.path.join(outdir + "/templates.hpp"), "wb") as f:
         f.write(datatext.encode('utf-8'))
 
-    print('Generate {}/template.hpp done.'.format(app))
+    print('Generate {}/template.hpp done.'.format(outdir))
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
This PR will relax the constraints that the main source of mros2 app should be "app.cpp" :D
In addition, we can specify multiple files at the same time.

Furthermore, this changes location to execute temlate_generator.py and output dir of template.hpp
also check: https://github.com/mROS-base/mros2-mbed/commit/b120d7c423f9abe8fead87975c5a24eb9885d1ca

```
$ pwd
/<snipned>/mros2-mbed/workspace/echoback_string

$ python3 ../../mros2/mros2_header_generator/templates_generator.py -h
Generate template.hpp from mros2 app code file.
usage: templates_generator.py [-h] [--outdir OUTDIR]
                              [--file [FILE [FILE ...]]]

Generate template.hpp from mros2 app code file.

optional arguments:
  -h, --help            show this help message and exit
  --outdir OUTDIR       directry name to output template.hpp (default: '.'
                        (current dir))
  --file [FILE [FILE ...]]
                        filename(s) of mros2 app code (default: 'app.cpp')
```