### PR TITLE
Refactor implementation of v0.5.1 and v.0.5.2

### DIFF
--- a/include/mros2.h
+++ b/include/mros2.h
@@ -86,9 +86,15 @@ namespace mros2
 
   void spin();
 
-  void setIPAddrRTPS(std::array<uint8_t, 4> ipaddr);
+#ifdef __MBED__
+  int setIPAddrRTPS(std::array<uint8_t, 4> ipaddr);
+#endif /* __MBED__ */
 
 } /* namespace mros2 */
+
+#ifndef __MBED__
+extern "C" int mros2_setIPAddrRTPS(uint32_t ipaddr);
+#endif /* __MBED__ */
 
 namespace message_traits
 {

--- a/mros2_header_generator/templates_generator.py
+++ b/mros2_header_generator/templates_generator.py
@@ -1,5 +1,5 @@
 import os
-import sys
+import glob
 import re
 import argparse
 from os import path
@@ -18,13 +18,16 @@ def main():
     parser = argparse.ArgumentParser(description='Generate template.hpp from mros2 app code file.')
     parser.add_argument('--outdir', default='.',
                     help='directry name to output template.hpp (default: \'.\' (current dir))')
-    parser.add_argument('--file', nargs='*', type=str, default=['app.cpp'],
-                    help='filename(s) of mros2 app code (default: \'app.cpp\')')
+    parser.add_argument('--indir', nargs='*', type=str, required=True,
+                    help='input dir(s) that contains mros2 app code (required)')
 
     args = parser.parse_args()
     outdir = args.outdir
-    file = args.file
+    indir = args.indir
+    file = []
 
+    for id in indir:
+        file = file + glob.glob(os.path.join(id, "*.cpp"))
     for f in file:
         print('  Analyzing \'{}\' to generate...'.format(f))
         with open(f, 'r') as m_f:

--- a/src/mros2.cpp
+++ b/src/mros2.cpp
@@ -303,14 +303,49 @@ namespace mros2
     }
   }
 
-  void setIPAddrRTPS(std::array<uint8_t, 4> ipaddr)
+  /* implementation for mros2-mbed */
+#ifdef __MBED__
+  int setIPAddrRTPS(std::array<uint8_t, 4> ipaddr)
   {
-    rtps::Config::IP_ADDRESS = ipaddr;
+    /* check whether IP address has been obtained */
+    if (!(ipaddr[0] + ipaddr[1] + ipaddr[2] + ipaddr[3]))
+    {
+      MROS2_ERROR("IP address has not been obtained!");
+      return 0;
+    }
 
-    MROS2_DEBUG("[MROS2LIB] set IP address for RTPS communication");
+    rtps::Config::IP_ADDRESS = ipaddr;
+    MROS2_DEBUG("[MROS2LIB] set \"%d.%d.%d.%d\" for RTPS communication",
+                rtps::Config::IP_ADDRESS[0], rtps::Config::IP_ADDRESS[1], rtps::Config::IP_ADDRESS[2], rtps::Config::IP_ADDRESS[3]);
+
+    return 1;
   }
+#endif /* __MBED__ */
 
 } /* namespace mros2 */
+
+/* implementation for mros2-esp32 */
+#ifndef __MBED__
+extern "C" int mros2_setIPAddrRTPS(uint32_t ipaddr)
+{
+  /* check whether IP address has been obtained */
+  if (!ipaddr)
+  {
+    MROS2_ERROR("IP address has not been obtained!");
+    return 0;
+  }
+
+  std::array<uint8_t, 4> rtps_ipaddr;
+  for (int i = 0; i < 4; i++)
+    rtps_ipaddr[i] = ipaddr >> (i * 8);
+
+  rtps::Config::IP_ADDRESS = rtps_ipaddr;
+  MROS2_DEBUG("[MROS2LIB] set \"%d.%d.%d.%d\" for RTPS communication",
+              rtps::Config::IP_ADDRESS[0], rtps::Config::IP_ADDRESS[1], rtps::Config::IP_ADDRESS[2], rtps::Config::IP_ADDRESS[3]);
+
+  return 1;
+}
+#endif /* __MBED__ */
 
 /*
  *  Declaration for embeddedRTPS participants


### PR DESCRIPTION
- for v0.5.1: implement setIPAddrRTPS for mros2-esp32 
  - because cpp module cannot be handled in `app_main()` and related functions in mros2-esp32 (ESP-IDF)
  - and also, add return value to check whether the network is surely connected, including for mros2-mbed (cpp module)
- for  v0.5.2: specify dir(s) that contains mros2 code files
  - we can now handle multiple files and/or dirs to generate `templates.hpp` (will fix https://github.com/mROS-base/mros2-mbed/issues/49)

The below is new usage for templates_generator.py
```
$ python3 mros2_header_generator/templates_generator.py --indir mros2_header_generator/ mros2_msgs/ -h
Generate template.hpp from mros2 app code file.
usage: templates_generator.py [-h] [--outdir OUTDIR] --indir
                              [INDIR [INDIR ...]]

Generate template.hpp from mros2 app code file.

optional arguments:
  -h, --help            show this help message and exit
  --outdir OUTDIR       directry name to output template.hpp (default: '.'
                        (current dir))
  --indir [INDIR [INDIR ...]]
                        input dir(s) that contains mros2 app code (required)
```