### PR TITLE
eliminate [-Wdepreated-declarations] warning message

### DIFF
--- a/src/mros2.cpp
+++ b/src/mros2.cpp
@@ -298,7 +298,7 @@ namespace mros2
       }
 #else  /* __MBED__ */
       // The queue above seems not to be pushed anywhere. So just sleep.
-      ThisThread::sleep_for(1000);
+      ThisThread::sleep_for(1s);
 #endif /* __MBED__ */
     }
   }


### PR DESCRIPTION
This PR is just eliminating warning message, so I will merge this without proper test.

```
/var/mbed/mros2/src/mros2.cpp: In function 'void mros2::spin()':
/var/mbed/mros2/src/mros2.cpp:301:33: warning: 'void rtos::ThisThread::sleep_for(uint32_t)' is deprecated: Pass a chrono duration, not an integer millisecond count. For example use `5s` rather than `5000`. [since mbed-os-6.0.0] [-Wdeprecated-declarations]
  301 |       ThisThread::sleep_for(1000);
      |                                 ^
In file included from /var/mbed/mbed-os/rtos/./include/rtos/rtos.h:30,
                 from /var/mbed/mbed-os/mbed.h:23,
                 from /var/mbed/mros2/src/mros2.cpp:6:
/var/mbed/mbed-os/rtos/./include/rtos/ThisThread.h:216:6: note: declared here
  216 | void sleep_for(uint32_t millisec);
      |      ^~~~~~~~~
```